### PR TITLE
#643 弾を相手側にも生成させる。

### DIFF
--- a/Assets/Battle/Bullet/Prefavs/Bullet.prefab
+++ b/Assets/Battle/Bullet/Prefavs/Bullet.prefab
@@ -11,6 +11,9 @@ GameObject:
   - 54: {fileID: 5463212}
   - 114: {fileID: 11407900}
   - 114: {fileID: 11470126}
+  - 148: {fileID: 14818426}
+  - 114: {fileID: 11442316}
+  - 114: {fileID: 11462010}
   m_Layer: 0
   m_Name: Bullet
   m_TagString: Untagged
@@ -122,6 +125,58 @@ MonoBehaviour:
   energy: 0
   speed: 5
   attackType: 0
+--- !u!114 &11442316
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 123884}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 372142912, guid: 870353891bb340e2b2a9c8707e7419ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SceneId:
+    m_Value: 0
+  m_AssetId:
+    i0: 205
+    i1: 21
+    i2: 204
+    i3: 184
+    i4: 255
+    i5: 227
+    i6: 225
+    i7: 20
+    i8: 171
+    i9: 136
+    i10: 61
+    i11: 213
+    i12: 167
+    i13: 104
+    i14: 102
+    i15: 176
+  m_ServerOnly: 0
+  m_LocalPlayerAuthority: 1
+--- !u!114 &11462010
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 123884}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1768714887, guid: 870353891bb340e2b2a9c8707e7419ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TransformSyncMode: 3
+  m_SendInterval: .100000001
+  m_SyncRotationAxis: 7
+  m_RotationSyncCompression: 0
+  m_SyncSpin: 0
+  m_MovementTheshold: .00100000005
+  m_SnapThreshold: 5
+  m_InterpolateRotation: 1
+  m_InterpolateMovement: 1
 --- !u!114 &11470126
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -146,6 +201,18 @@ CapsuleCollider:
   m_Height: 2
   m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!148 &14818426
+NetworkView:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 123884}
+  m_Enabled: 1
+  m_StateSynchronization: 1
+  m_Observed: {fileID: 474650}
+  m_ViewID:
+    m_ID: 0
+    m_Type: 0
 --- !u!1001 &100100000
 Prefab:
   m_ObjectHideFlags: 1
@@ -159,6 +226,74 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 0}
       propertyPath: m_IsTrigger
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_AssetId.i0
+      value: 205
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_AssetId.i1
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_AssetId.i2
+      value: 204
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_AssetId.i3
+      value: 184
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_AssetId.i4
+      value: 255
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_AssetId.i5
+      value: 227
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_AssetId.i6
+      value: 225
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_AssetId.i7
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_AssetId.i8
+      value: 171
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_AssetId.i9
+      value: 136
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_AssetId.i10
+      value: 61
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_AssetId.i11
+      value: 213
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_AssetId.i12
+      value: 167
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_AssetId.i13
+      value: 104
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_AssetId.i14
+      value: 102
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_AssetId.i15
+      value: 176
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_LocalPlayerAuthority
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []

--- a/Assets/Battle/Player/BoostManager.cs
+++ b/Assets/Battle/Player/BoostManager.cs
@@ -57,7 +57,6 @@ public class BoostManager : MonoBehaviour {
 	void Update () {
         AutoRegain();
 
-        Debug.Log(Quantity);
 	}
 
     void AutoRegain()

--- a/Assets/Battle/Player/Player.prefab
+++ b/Assets/Battle/Player/Player.prefab
@@ -54,10 +54,11 @@ GameObject:
   - 114: {fileID: 11437544}
   - 114: {fileID: 11495572}
   - 114: {fileID: 11486332}
-  - 148: {fileID: 14831838}
   - 114: {fileID: 11450436}
-  - 114: {fileID: 11494558}
   - 114: {fileID: 11463666}
+  - 114: {fileID: 11436166}
+  - 148: {fileID: 14865354}
+  - 114: {fileID: 11442878}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -286,6 +287,18 @@ MonoBehaviour:
   moveSpeed: 4
   distanceFromTarget: -4
   addHeight: 3
+--- !u!114 &11436166
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 130908}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c0aec9c2412c8e34787ce9830c017cac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bullet: {fileID: 123884, guid: cd15ccb8ffe3e114ab883dd5a76866b0, type: 2}
 --- !u!114 &11437544
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -338,6 +351,26 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   boostPower: .300000012
   boostConsumption: .300000012
+--- !u!114 &11442878
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 130908}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1768714887, guid: 870353891bb340e2b2a9c8707e7419ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TransformSyncMode: 3
+  m_SendInterval: .100000001
+  m_SyncRotationAxis: 7
+  m_RotationSyncCompression: 0
+  m_SyncSpin: 0
+  m_MovementTheshold: .00100000005
+  m_SnapThreshold: 5
+  m_InterpolateRotation: 1
+  m_InterpolateMovement: 1
 --- !u!114 &11448422
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -442,26 +475,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   robotTextureID: -1
---- !u!114 &11494558
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 130908}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -1768714887, guid: 870353891bb340e2b2a9c8707e7419ba, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_TransformSyncMode: 3
-  m_SendInterval: .100000001
-  m_SyncRotationAxis: 7
-  m_RotationSyncCompression: 0
-  m_SyncSpin: 0
-  m_MovementTheshold: .00100000005
-  m_SnapThreshold: 5
-  m_InterpolateRotation: 1
-  m_InterpolateMovement: 1
 --- !u!114 &11495572
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -506,7 +519,7 @@ CapsuleCollider:
   m_Height: 2
   m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
---- !u!148 &14831838
+--- !u!148 &14865354
 NetworkView:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
@@ -1613,7 +1626,23 @@ Prefab:
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
-    m_Modifications: []
+    m_Modifications:
+    - target: {fileID: 0}
+      propertyPath: bullet
+      value: 
+      objectReference: {fileID: 123884, guid: cd15ccb8ffe3e114ab883dd5a76866b0, type: 2}
+    - target: {fileID: 0}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_ServerOnly
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_LocalPlayerAuthority
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 130908}

--- a/Assets/Battle/Player/PlayerShooter.cs
+++ b/Assets/Battle/Player/PlayerShooter.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using System.Collections;
+using UnityEngine.Networking;
 
 public class PlayerShooter : MonoBehaviour {
 
@@ -17,14 +18,42 @@ public class PlayerShooter : MonoBehaviour {
     /// </summary>
     float shotDeltaTime = 0.0f;
 
+    NetworkView myNetworkView = null;
+
+    void Start()
+    {
+        myNetworkView = GetComponent<NetworkView>();
+    }
+
 	// Update is called once per frame
 	void Update () {
-	    if(Input.GetAxis("Fire1") != 0 && shotDeltaTime < 0.0f)
+
+        if (IsCheckCreate())
         {
-            var clone = (GameObject)Instantiate(bullet,transform.position,Quaternion.identity);
-            clone.transform.forward = transform.forward;
             shotDeltaTime = NeedCoolTime;
+
+            var clone = (GameObject)Network.Instantiate(bullet,transform.position,Quaternion.identity,1);
+            clone.transform.forward = transform.forward;
         }
-        shotDeltaTime -= Time.deltaTime;
 	}
+
+    /// <summary>
+    /// 生成できるかどうかをチェックする。
+    /// </summary>
+    /// <returns></returns>
+    bool IsCheckCreate()
+    {
+        if (!myNetworkView.isMine) return false;
+
+        shotDeltaTime -= Time.deltaTime;
+        if (Input.GetAxis("Fire1") != 0 && shotDeltaTime < 0.0f)
+        {
+            return true;
+        }
+        return false;
+    }
+
+
+
+
 }

--- a/Assets/Network/NetworkManager.prefab
+++ b/Assets/Network/NetworkManager.prefab
@@ -52,7 +52,8 @@ MonoBehaviour:
   m_PlayerSpawnMethod: 0
   m_OfflineScene: 
   m_OnlineScene: 
-  m_SpawnPrefabs: []
+  m_SpawnPrefabs:
+  - {fileID: 130908, guid: 8f3fea2b5b22c954892b46b9c384fd5c, type: 2}
   m_CustomConfig: 0
   m_MaxConnections: 4
   m_ConnectionConfig:

--- a/Assets/Network/NetworkPlayerSetup.cs
+++ b/Assets/Network/NetworkPlayerSetup.cs
@@ -2,19 +2,21 @@
 using System.Collections;
 using UnityEngine.Networking;
 
-public class NetworkPlayerSetup : NetworkBehaviour {
+public class NetworkPlayerSetup : MonoBehaviour {
 
     GameObject sceneCamera = null;
+    NetworkView myNetworkView = null;
 
 	// Use this for initialization
 	void Start () {
+        myNetworkView = GetComponent<NetworkView>();
         sceneCamera =  GameObject.Find("Scene Camera");
         OpponentDestroy();
 
         if(sceneCamera != null)
             sceneCamera.SetActive(false);
 
-        if (isLocalPlayer)
+        if (myNetworkView.isMine)
         {
             transform.FindChild("Main Camera").parent = null;
         }
@@ -25,10 +27,11 @@ public class NetworkPlayerSetup : NetworkBehaviour {
     /// </summary>
     void OpponentDestroy()
     {
-        if (!isLocalPlayer)
+        if (!myNetworkView.isMine)
         {
             Destroy(GetComponent<PlayerMover>());
             Destroy(GetComponent<PlayerJumper>());
+          //  Destroy(GetComponent<PlayerShooter>());
             Destroy(transform.FindChild("Main Camera").gameObject);
         }
     }

--- a/Assets/NetworkManagerSetup.cs
+++ b/Assets/NetworkManagerSetup.cs
@@ -1,0 +1,61 @@
+﻿using UnityEngine;
+using System.Collections;
+
+public class NetworkManagerSetup : MonoBehaviour {
+
+    [SerializeField]
+    GameObject objectPrefab;
+    
+    [SerializeField]
+    string ip = "localhost";
+
+    [SerializeField]
+    string port = "7777";
+    
+    bool connected = false;
+
+    //サーバ立ち上げ時に呼ばれるメソッド
+    public void OnServerInitialized()
+    {
+        connected = true;
+        //ネットワーク内のすべてのPCでインスタンス化が行われるメソッド
+        Network.Instantiate(objectPrefab, objectPrefab.transform.position, objectPrefab.transform.rotation, 1);
+    }
+
+    //サーバに接続したときに呼ばれるメソッド
+    public void OnConnectedToServer()
+    {
+        connected = true;
+        Network.Instantiate(objectPrefab, objectPrefab.transform.position, objectPrefab.transform.rotation, 2);
+    }
+		
+	// Use this for initialization
+	void Start () {
+	}
+
+    public void OnGUI()
+    {
+        if (!connected)
+        {
+            GUI.Label(new Rect(40, 250, 100, 30), "HOST IP");
+            Rect rect1 = new Rect(100, 250, 250, 30);
+            ip = GUI.TextField(rect1, ip, 32);
+
+            if (GUI.Button(new Rect(10, 10, 90, 90), "Client"))
+            {
+                //(hostのIPアドレス,hostが接続を受け入れているポート番号)
+                Network.Connect(ip, int.Parse(port));
+            }
+
+            if (GUI.Button(new Rect(10, 110, 90, 90), "Server"))
+            {
+                //(接続可能人数,接続を受け入れるポート番号,NATのパンチスルー機能の設定)
+                Network.InitializeServer(10, int.Parse(port), false);
+            }
+        }
+    }
+	// Update is called once per frame
+	void Update () {
+	
+	}
+}

--- a/Assets/NetworkManagerSetup.cs.meta
+++ b/Assets/NetworkManagerSetup.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 448c02502da78ce428225e14829c4d07
+timeCreated: 1436015911
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scene/Battle.unity
+++ b/Assets/Scene/Battle.unity
@@ -126,6 +126,18 @@ Prefab:
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
+    - target: {fileID: 11431078, guid: 794d686b2df09b24f8b50bdaf5bcc225, type: 2}
+      propertyPath: m_SpawnPrefabs.Array.data[0]
+      value: 
+      objectReference: {fileID: 123884, guid: cd15ccb8ffe3e114ab883dd5a76866b0, type: 2}
+    - target: {fileID: 11451254, guid: 794d686b2df09b24f8b50bdaf5bcc225, type: 2}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 11431078, guid: 794d686b2df09b24f8b50bdaf5bcc225, type: 2}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 794d686b2df09b24f8b50bdaf5bcc225, type: 2}
   m_IsPrefabParent: 0
@@ -256,6 +268,24 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 796eaceea951e754a8cb4aa5a1ca3341, type: 2}
   m_IsPrefabParent: 0
+--- !u!1 &1495739949 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 137150, guid: 794d686b2df09b24f8b50bdaf5bcc225, type: 2}
+  m_PrefabInternal: {fileID: 652437110}
+--- !u!114 &1495739953
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1495739949}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 448c02502da78ce428225e14829c4d07, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  objectPrefab: {fileID: 130908, guid: 8f3fea2b5b22c954892b46b9c384fd5c, type: 2}
+  ip: localhost
+  port: 7777
 --- !u!1 &2129335114
 GameObject:
   m_ObjectHideFlags: 0

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -187,7 +187,7 @@ InputManager:
     descriptiveNegativeName: 
     negativeButton: 
     positiveButton: joystick button 0
-    altNegativeButton: 
+    altNegativeButton: z
     altPositiveButton: 
     gravity: 1000
     dead: .00100000005


### PR DESCRIPTION
# 実装した内容
* 相手側が撃った弾を同期させた。
* 相手が撃つと自分側にも生成され、見えるようになる。


# 追加・更新したスクリプト
* NetworkManagerSetup.cs
    * ここで、ネットワークのMatchingをしている。
* PlayerShooter.cs
    * 弾の生成は、Network用のInstantiateを使用している。

# ネットワークについて
* UNETでのNetworkManagerはMatchingやゲームオブジェクトの生成に不便でしたので、以前のNetwork機能を使用している。
* ゲームオブジェクトを生成するときは、  
`Network.Instantiate(GameObject,Vector3 pos,Quotanion rotate,int grup);`  
を使ってください！
* 自分側の操作かどうかは、NetworkViewをCOmponentして、inMineでわかります。 true...自分 

以上です。
